### PR TITLE
update response year in the footer

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,11 +1,10 @@
-import { FaCopyright } from "react-icons/fa"
 
 const Footer = () => {
   return (
     <div className="footer-p">
       <footer className="footer py-7">
         <div className="container-footer">
-          <span className="text-muted">My Cocktail | <FaCopyright /> Copyright | 2023</span>
+        <span className="text-muted">My Cocktail | &copy; Copyright | { new Date().getFullYear()}</span>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
a small tweak to make the year responsive, rather than being static as text. 
Link to video: https://www.google.com/search?q=how+to+create+a+responsive+date+footer+in+react&oq=how+to+create+a+responsive+date+footer+in+react&aqs=chrome..69i57j33i10i160l2.11205j0j7&sourceid=chrome&ie=UTF-8#fpstate=ive&vld=cid:10bd2f76,vid:g459Eia-bxw