### PR TITLE
updated footer span line to get year

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,11 +1,10 @@
-import { FaCopyright } from "react-icons/fa"
 
 const Footer = () => {
   return (
     <div className="footer-p">
       <footer className="footer py-7">
         <div className="container-footer">
-          <span className="text-muted">My Cocktail | <FaCopyright /> Copyright | 2023</span>
+        <span className="text-muted">My Cocktail | &copy; Copyright | { new Date().getFullYear()}</span>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
![Screen Shot 2023-02-02 at 3 55 50 pm](https://user-images.githubusercontent.com/51424250/216243460-11f14320-2a25-4bea-ade4-a0fc45a3aee9.png)

Not sure if image works, trying something new. 

* removed React icon Copyright. 
* updated Span line to include getFullYear 